### PR TITLE
open parameter "errors" should be error handler, not encoding (Issue #226)

### DIFF
--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -269,7 +269,7 @@ def run_cmd(cmd: List[str], *, print_output: bool) -> Tuple[int, List[str]]:
         stdout=PIPE,
         stderr=STDOUT,
         encoding="utf-8",
-        errors="utf-8",
+        errors="replace",
         shell=with_shell,
     )
     stdout = []


### PR DESCRIPTION
see issue [open parameter "errors" should be error handler, not encoding #226](https://github.com/yehoshuadimarsky/bcpandas/issues/226)

Hi,

I stumbled upon a bug in stdout decoding when running your lib against an SQL Server configured to German and returning "öß".

At following point of code, an error handling method needs to be specified, not an encoding:

https://github.com/yehoshuadimarsky/bcpandas/blob/888928081a82a8f73a730d388dff25a0a28ed866/bcpandas/utils.py#L272

```diff
    proc = Popen(
        cmd,
        stdout=PIPE,
        stderr=STDOUT,
        encoding="utf-8",
-       errors="utf-8",
+       errors="replace",
        shell=with_shell,
    )
```

see https://docs.python.org/3/library/io.html#io.TextIOWrapper for reference